### PR TITLE
python-consul2 as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ tests_require = [
 requires = [ 'python-consul2', ]
 
 setup(name='consulock',
-      version='0.4.2',
+      version='0.4.3',
       description=README,
       long_description=README,
       url='https://github.com/haarcuba/consulock',

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ tests_require = [
     ]
 
 
-requires = [ 'python-consul', ]
+requires = [ 'python-consul2', ]
 
 setup(name='consulock',
-      version='0.4.1',
+      version='0.4.2',
       description=README,
       long_description=README,
       url='https://github.com/haarcuba/consulock',


### PR DESCRIPTION
Using python-consul2 as dependency because python-consul is not maintained.